### PR TITLE
fixed ngSwipeLeft and ngSwipeRight conflict with ngTouch

### DIFF
--- a/dist/angular-swipe.js
+++ b/dist/angular-swipe.js
@@ -162,8 +162,12 @@
 
   // Left is negative X-coordinate, right is positive
 
-  makeSwipeDirective('ngSwipeLeft', -1, false, 'swipeleft');
-  makeSwipeDirective('ngSwipeRight', 1, false, 'swiperight');
+  try {
+    angular.module("ngTouch");
+  } catch(err) {
+    makeSwipeDirective('ngSwipeLeft', -1, false, 'swipeleft');
+    makeSwipeDirective('ngSwipeRight', 1, false, 'swiperight');
+  }
 
   makeSwipeDirective('ngSwipeUp', -1, true, 'swipeup');
   makeSwipeDirective('ngSwipeDown', 1, true, 'swipedown');


### PR DESCRIPTION
Checks if `ngTouch` is used, and created `ngSwipeLeft` and `ngSwipeRight` only if it's not. May not work if `ngTouch` is specified as dependency after `swipe`.

You still have to update the minified version.
