### PR TITLE
Added ngTap event directive

### DIFF
--- a/src/angular-swipe.js
+++ b/src/angular-swipe.js
@@ -158,18 +158,22 @@
           var deltaY = (coords.y - startCoords.y) * direction;
           var deltaX = (coords.x - startCoords.x) * direction;
 
-          if (! axis){  // horizontal swipe
+          if(axis === null) { // tap
+              return Math.abs(deltaY) < MIN_DISTANCE &&
+                     Math.abs(deltaX) < MIN_DISTANCE;
+          }
+          else if(axis === false) {  // horizontal swipe
             return Math.abs(deltaY) < MAX_OTHER_AXIS_DISTANCE &&
               deltaX > 0 &&
               deltaX > MIN_DISTANCE &&
               Math.abs(deltaY) / deltaX < MAX_RATIO;
-          } else {  // vertical swipe
+          }
+          else {  // vertical swipe
             return Math.abs(deltaX) < MAX_OTHER_AXIS_DISTANCE &&
               deltaY > 0 &&
               deltaY > MIN_DISTANCE &&
               Math.abs(deltaX) / deltaY < MAX_RATIO;
           }
-
         }
 
         var pointerTypes = ['touch'];
@@ -216,5 +220,7 @@
 
   makeSwipeDirective('ngSwipeUp', -1, true, 'swipeup');
   makeSwipeDirective('ngSwipeDown', 1, true, 'swipedown');
+
+  makeSwipeDirective('ngTap', 1, null, 'tap');
 
 })(window, window.angular);


### PR DESCRIPTION
In addition to swiping I needed to capture a simple tap event but the binding was overriding the ability to capture other click and touch events. So I added a tap directive that fires when the delta for both axis is too small for a swipe.
